### PR TITLE
Setting up monitoring stack, automatic authentication to grafana

### DIFF
--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -31,3 +31,43 @@
     - name: Display cluster nodes
       debug:
         msg: "{{ nodes_output.stdout_lines }}"
+
+- name: Setup Prometheus & Grafana Monitoring
+  hosts: control_plane
+  become: false  # Running as 'ubuntu' so it uses the correct ~/.kube/config
+  tasks:
+    - name: Download Helm install script
+      get_url:
+        url: https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+        dest: /tmp/get_helm.sh
+        mode: '0700'
+
+    - name: Install Helm binary
+      become: true  # Needs root to put Helm in /usr/local/bin
+      command: /tmp/get_helm.sh
+      args:
+        creates: /usr/local/bin/helm
+
+    - name: Add Prometheus community Helm repository
+      command: helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+      environment:
+        KUBECONFIG: /home/ubuntu/.kube/config
+
+    - name: Update Helm repositories
+      command: helm repo update
+      environment:
+        KUBECONFIG: /home/ubuntu/.kube/config
+
+    - name: Install kube-prometheus-stack
+      command: >
+        helm upgrade --install monitoring prometheus-community/kube-prometheus-stack
+        --namespace monitoring
+        --create-namespace
+      environment:
+        KUBECONFIG: /home/ubuntu/.kube/config
+
+    - name: Fetch kubeconfig back to your machine
+      fetch:
+        src: /home/ubuntu/.kube/config
+        dest: ~/.kube/config
+        flat: yes

--- a/api/config.py
+++ b/api/config.py
@@ -8,12 +8,20 @@ WORKSPACES_DIR = os.path.join(PROJECT_ROOT, 'workspaces')
 DATA_DIR = os.path.join(PROJECT_ROOT, 'data')
 DB_PATH = os.path.join(DATA_DIR, 'api.db')
 
+GRAFANA_URL = os.getenv("GRAFANA_URL", "http://localhost:3000")
+GRAFANA_USER = os.getenv("GRAFANA_USER", "admin")
+GRAFANA_PASSWORD = os.getenv("GRAFANA_PASSWORD", "SPskU5XpwtTtAnEdXwM34WbQ5E9Nsna377nb8ql8")
+GRAFANA_DASHBOARD_PATH = os.getenv("GRAFANA_DASHBOARD_PATH", "/d/efa86fd1d0c121a26444b636a3f509a8/kubernetes-compute-resources-cluster?orgId=1&from=now-1h&to=now&timezone=utc&var-datasource=default&var-cluster=&refresh=10s")
+
 # Network defaults (override via environment variables)
 VM_IP_PREFIX = os.getenv('VM_IP_PREFIX', '10.40.19.')
 VM_IP_START = int(os.getenv('VM_IP_START', '201'))
 VM_IP_GATEWAY = os.getenv('VM_IP_GATEWAY', '10.40.19.254')
 VM_DNS_SERVER = os.getenv('VM_DNS_SERVER', '10.40.2.1')
 
+# --- NEW: SSH & Jump Host Configuration ---
+CLUSTER_SSH_PASSWORD = os.getenv('CLUSTER_SSH_PASSWORD', 'your_ssh_password_here')
+JUMP_HOST = os.getenv('JUMP_HOST', 'user@tesla.ce.pdn.ac.lk')
 
 def read_base_tfvars() -> dict:
     """Read Proxmox credentials and defaults from the base terraform.tfvars."""

--- a/api/database.py
+++ b/api/database.py
@@ -1,8 +1,9 @@
 import os
 import sqlite3
-
+import logging
 from . import config
 
+logger = logging.getLogger(__name__)
 
 def get_db() -> sqlite3.Connection:
     os.makedirs(config.DATA_DIR, exist_ok=True)
@@ -11,9 +12,9 @@ def get_db() -> sqlite3.Connection:
     conn.execute("PRAGMA foreign_keys = ON")
     return conn
 
-
 def init_db():
     conn = get_db()
+    # 1. Run the base schema
     conn.executescript("""
         CREATE TABLE IF NOT EXISTS environments (
             id TEXT PRIMARY KEY,
@@ -31,6 +32,7 @@ def init_db():
             status TEXT NOT NULL DEFAULT 'creating',
             ip_start INTEGER NOT NULL,
             environment_id TEXT REFERENCES environments(id) ON DELETE SET NULL,
+            grafana_password TEXT, 
             created_at TEXT NOT NULL
         );
 
@@ -85,15 +87,28 @@ def init_db():
             UNIQUE(user_id, resource_type, resource_id)
         );
     """)
+    
+    # 2. Run migrations for existing databases
+    _migrate(conn)
+    
     conn.commit()
     conn.close()
 
-
 def _migrate(conn: sqlite3.Connection):
-    """Run any necessary schema migrations."""
-    # Drop UNIQUE constraint on clusters.name so deleted cluster names can be reused
+    """Run necessary schema migrations for existing databases."""
+    
+    # Check if grafana_password column exists
+    cursor = conn.execute("PRAGMA table_info(clusters)")
+    columns = [row['name'] for row in cursor.fetchall()]
+    
+    if 'grafana_password' not in columns:
+        logger.info("Migration: Adding grafana_password column to clusters table")
+        conn.execute("ALTER TABLE clusters ADD COLUMN grafana_password TEXT")
+
+    # Drop UNIQUE constraint on clusters.name if it still exists
     row = conn.execute("SELECT sql FROM sqlite_master WHERE type='table' AND name='clusters'").fetchone()
     if row and 'name TEXT UNIQUE' in row[0]:
+        logger.info("Migration: Removing UNIQUE constraint from clusters.name")
         conn.executescript("""
             PRAGMA foreign_keys = OFF;
             ALTER TABLE clusters RENAME TO _clusters_old;
@@ -106,9 +121,12 @@ def _migrate(conn: sqlite3.Connection):
                 status TEXT NOT NULL DEFAULT 'creating',
                 ip_start INTEGER NOT NULL,
                 environment_id TEXT REFERENCES environments(id) ON DELETE SET NULL,
+                grafana_password TEXT,
                 created_at TEXT NOT NULL
             );
-            INSERT INTO clusters SELECT * FROM _clusters_old;
+            INSERT INTO clusters (id, name, node_count, control_plane_count, worker_count, status, ip_start, environment_id, created_at)
+            SELECT id, name, node_count, control_plane_count, worker_count, status, ip_start, environment_id, created_at 
+            FROM _clusters_old;
             DROP TABLE _clusters_old;
             PRAGMA foreign_keys = ON;
         """)

--- a/api/main.py
+++ b/api/main.py
@@ -8,7 +8,7 @@ from fastapi.staticfiles import StaticFiles
 
 from .database import init_db
 from .errors import APIError, api_error_handler
-from .routers import auth, clusters, environments, namespaces, users
+from .routers import auth, clusters, environments, namespaces, users, monitor
 
 STATIC_DIR = pathlib.Path(__file__).parent / "static"
 
@@ -57,6 +57,7 @@ app.include_router(clusters.router, prefix="/api/v1", tags=["clusters"])
 app.include_router(environments.router, prefix="/api/v1", tags=["environments"])
 app.include_router(namespaces.router, prefix="/api/v1", tags=["namespaces"])
 app.include_router(users.router, prefix="/api/v1", tags=["users"])
+app.include_router(monitor.router)
 
 app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,2 +1,3 @@
 fastapi>=0.110.0
 uvicorn[standard]>=0.27.0
+httpx

--- a/api/routers/monitor.py
+++ b/api/routers/monitor.py
@@ -1,0 +1,84 @@
+import httpx
+import base64
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import RedirectResponse
+from ..database import get_db
+from ..services.kubectl import run_kubectl 
+
+from ..config import (
+    GRAFANA_URL,
+    GRAFANA_USER,
+    GRAFANA_DASHBOARD_PATH,
+)
+
+router = APIRouter(
+    prefix="/monitor",
+    tags=["Monitoring"]
+)
+
+def fetch_cluster_password(cluster_id: str) -> str:
+    """Helper to grab the password from K8s via SSH/Kubectl."""
+    args = [
+        "get", "secret", "-n", "monitoring", 
+        "monitoring-grafana", 
+        "-o", "jsonpath='{.data.admin-password}'"
+    ]
+    encoded_pw = run_kubectl(cluster_id, args)
+    clean_pw = encoded_pw.strip().strip("'").strip('"')
+    return base64.b64decode(clean_pw).decode('utf-8')
+
+
+# cluster_id from the URL
+@router.get("/open/{cluster_id}")
+async def open_monitor(cluster_id: str):
+    db = get_db()
+    try:
+        cluster = db.execute(
+            "SELECT id, grafana_password FROM clusters WHERE id = ?",
+            (cluster_id,)
+        ).fetchone()
+        
+        if not cluster:
+            raise HTTPException(status_code=404, detail="Cluster not found in database.")
+            
+        password = cluster['grafana_password']
+        
+        # Fetching the password using SSH
+        if not password:
+            try:
+                password = fetch_cluster_password(cluster_id)
+                db.execute(
+                    "UPDATE clusters SET grafana_password = ? WHERE id = ?", 
+                    (password, cluster_id)
+                )
+                db.commit()
+            except Exception as e:
+                raise HTTPException(status_code=500, detail=f"Failed to fetch password: {str(e)}")
+
+        # Authentication to Grafana and redirect
+        login_credentials = {
+            "user": GRAFANA_USER,
+            "password": password
+        }
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(f"{GRAFANA_URL}/login", json=login_credentials)
+
+            if response.status_code == 200:
+                session_cookie = response.cookies.get("grafana_session")
+                target_url = f"{GRAFANA_URL}{GRAFANA_DASHBOARD_PATH}"
+                redirect = RedirectResponse(url=target_url)
+
+                redirect.set_cookie(
+                    key="grafana_session",
+                    value=session_cookie,
+                    httponly=True
+                )
+                return redirect
+            else:
+                raise HTTPException(
+                    status_code=500, 
+                    detail="Internal monitoring authentication failed."
+                )
+    finally:
+        db.close()

--- a/api/services/kubectl.py
+++ b/api/services/kubectl.py
@@ -20,25 +20,62 @@ def _get_control_plane_ip(cluster_id: str) -> str:
 
 
 def run_kubectl(cluster_id: str, args: list[str], timeout: int = 30) -> str:
-    """Run a kubectl command on the cluster's control plane via SSH (paramiko)."""
+    """Run a kubectl command on the cluster's control plane via Paramiko SSH through a Jump Host."""
     ip = _get_control_plane_ip(cluster_id)
     base = config.read_base_tfvars()
-    user = base.get("ssh_user", "ubuntu")
-    password = base.get("ssh_password", "ubuntu")
+    
+    # Target VM credentials
+    target_user = base.get("ssh_user", "ubuntu")
+    target_password = base.get("ssh_password", config.CLUSTER_SSH_PASSWORD)
 
     cmd = "kubectl " + " ".join(args)
     logger.info("[%s] %s on %s", cluster_id, cmd, ip)
 
-    client = paramiko.SSHClient()
-    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    # Parse Jump Host config 
+    jump_user, jump_host = config.JUMP_HOST.split("@")
+
+    jump_client = paramiko.SSHClient()
+    jump_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    
+    target_client = paramiko.SSHClient()
+    target_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
     try:
-        client.connect(ip, username=user, password=password, timeout=10, look_for_keys=False)
-        _, stdout, stderr = client.exec_command(cmd, timeout=timeout)
+        #Connect to the Jump Host first -change the cofig.
+        jump_client.connect(
+            jump_host, 
+            username=jump_user, 
+            look_for_keys=True, 
+            timeout=10
+        )
+
+        #Open a direct TCP tunnel from the Jump Host to the Target VM
+        jump_transport = jump_client.get_transport()
+        dest_addr = (ip, 22)
+        local_addr = ('127.0.0.1', 0) 
+        tunnel_channel = jump_transport.open_channel("direct-tcpip", dest_addr, local_addr)
+
+        # Connect to the Target VM through the tunnel using the password
+        target_client.connect(
+            ip, 
+            username=target_user, 
+            password=target_password, 
+            sock=tunnel_channel, 
+            look_for_keys=False, 
+            timeout=10
+        )
+
+        #Execute the command on the target VM
+        _, stdout, stderr = target_client.exec_command(cmd, timeout=timeout)
         exit_code = stdout.channel.recv_exit_status()
         out = stdout.read().decode().strip()
         err = stderr.read().decode().strip()
+
         if exit_code != 0:
             raise RuntimeError(f"kubectl failed: {err}")
+        
         return out
+
     finally:
-        client.close()
+        target_client.close()
+        jump_client.close()

--- a/api/services/provisioner.py
+++ b/api/services/provisioner.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import shutil
 import subprocess
 import threading
@@ -51,7 +52,7 @@ def _setup_workspace(cluster_id: str) -> str:
             src = os.path.join(config.TERRAFORM_DIR, f)
             dst = os.path.join(tf_dir, f)
             if not os.path.exists(dst):
-                os.symlink(src, dst)
+                shutil.copy(src, dst)
     return tf_dir
 
 
@@ -61,9 +62,12 @@ def _generate_tfvars(tf_dir: str, cluster_id: str):
     db.close()
 
     base = config.read_base_tfvars()
+    #  some names the proxmox doesn't approve. For that as a fix - (example: "Test Cluster 1" -> "test-cluster-1")
+    safe_name = re.sub(r'[^a-z0-9-]', '-', cluster["name"].lower())
 
+    # NOTE: 
     lines = [
-        f'proxmox_api_url          = "{base.get("proxmox_api_url", "")}"',
+        f'proxmox_api_url          = "https://127.0.0.1:8006/api2/json"',
         f'proxmox_api_token_id     = "{base.get("proxmox_api_token_id", "")}"',
         f'proxmox_api_token_secret = "{base.get("proxmox_api_token_secret", "")}"',
         '',
@@ -83,13 +87,34 @@ def _generate_tfvars(tf_dir: str, cluster_id: str):
 
 
 def _run_cmd(args: list[str], cwd: str, env: dict | None = None, timeout: int = 1800) -> str:
-    result = subprocess.run(args, cwd=cwd, capture_output=True, text=True, timeout=timeout, env=env)
-    if result.returncode != 0:
-        output = (result.stderr or '') + (result.stdout or '')
-        # Keep only last 2000 chars to avoid huge DB entries
-        output = output[-2000:] if len(output) > 2000 else output
-        raise RuntimeError(f"{args[0]} failed (exit {result.returncode}): {output}")
-    return result.stdout
+    print(f"\n --- STARTING COMMAND: {' '.join(args)} ---\n")
+    
+    # Use Popen to stream logs in real-time
+    process = subprocess.Popen(
+        args, 
+        cwd=cwd, 
+        env=env, 
+        stdout=subprocess.PIPE, 
+        stderr=subprocess.STDOUT, 
+        text=True,
+        bufsize=1
+    )
+    
+    output_lines = []
+    for line in process.stdout:
+        print(line, end="")  # Instantly prints to terminal
+        output_lines.append(line)
+        
+    process.wait(timeout=timeout)
+    full_output = "".join(output_lines)
+    
+    print(f"\n --- FINISHED COMMAND (Exit Code: {process.returncode}) ---\n")
+    
+    if process.returncode != 0:
+        short_output = full_output[-2000:] if len(full_output) > 2000 else full_output
+        raise RuntimeError(f"{args[0]} failed (exit {process.returncode}): {short_output}")
+        
+    return full_output
 
 
 def _provision_cluster(cluster_id: str, job_id: str):
@@ -113,7 +138,11 @@ def _provision_cluster(cluster_id: str, job_id: str):
 
         env = os.environ.copy()
         env['ANSIBLE_CONFIG'] = os.path.join(config.ANSIBLE_DIR, 'ansible.cfg')
+        
+        # Hardened SSH connection for firewall drops
         env['ANSIBLE_HOST_KEY_CHECKING'] = 'False'
+        env['ANSIBLE_SSH_ARGS'] = '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ControlMaster=no -o ServerAliveInterval=30 -o ServerAliveCountMax=5 -o ConnectTimeout=60'
+        env['ANSIBLE_RETRIES'] = '3'
 
         logger.info("[%s] ansible-playbook", cluster_id)
         _run_cmd(['ansible-playbook', '-i', inventory, site_yml], cwd=config.ANSIBLE_DIR, env=env, timeout=3600)
@@ -123,6 +152,7 @@ def _provision_cluster(cluster_id: str, job_id: str):
         logger.info("[%s] provisioning complete", cluster_id)
 
     except Exception as e:
+        print(f"\n[!!!] CRITICAL PROVISIONING ERROR: {e}\n")
         logger.error("[%s] provisioning failed: %s", cluster_id, e)
         _update_job(job_id, 'failed', str(e))
         _update_cluster(cluster_id, 'failed')
@@ -154,6 +184,7 @@ def _destroy_cluster(cluster_id: str, job_id: str):
         logger.info("[%s] destruction complete", cluster_id)
 
     except Exception as e:
+        print(f"\n[!!!] CRITICAL DESTRUCTION ERROR: {e}\n")
         logger.error("[%s] destruction failed: %s", cluster_id, e)
         _update_job(job_id, 'failed', str(e))
         _update_cluster(cluster_id, 'failed')

--- a/api/static/index.html
+++ b/api/static/index.html
@@ -423,21 +423,40 @@ async function loadClusters() {
   try {
     const data = await apiFetch('/clusters');
     if (!data.length) { el.innerHTML = emptyState('No clusters yet'); _stopClusterPoll(); return; }
+    
+    // "Monitor" header 
     el.innerHTML = `<table>
-      <tr><th>ID</th><th>Name</th><th>Nodes</th><th>Control Plane</th><th>Workers</th><th>Status</th><th>Latest Job</th><th>Created</th><th></th></tr>
-      ${data.map(c => `<tr>
-        <td class="mono">${esc(c.id)}</td>
-        <td>${esc(c.name)}</td>
-        <td>${c.node_count}</td>
-        <td class="mono" style="font-size:11px">${c.nodes.control_plane.join(', ')}</td>
-        <td class="mono" style="font-size:11px">${c.nodes.workers.join(', ')}</td>
-        <td>${badge(c.status)}</td>
-        <td>${c.latest_job_id ? `<a href="#" class="mono" style="font-size:12px" onclick="event.preventDefault();goToJob('${c.latest_job_id}')">${esc(c.latest_job_id)}</a>` : '—'}</td>
-        <td style="font-size:12px; color:var(--muted)">${timeAgo(c.created_at)}</td>
-        <td><button class="btn btn-danger btn-sm" onclick="deleteCluster('${c.id}')">Delete</button></td>
-      </tr>`).join('')}
+      <tr><th>ID</th><th>Name</th><th>Nodes</th><th>Control Plane</th><th>Workers</th><th>Status</th><th>Latest Job</th><th>Created</th><th>Monitor</th><th></th></tr>
+      ${data.map(c => {
+        
+        const monitorUrl = `/monitor/open/${c.id}`;
+
+        const isRunning = c.status === 'running';
+        const buttonDisabled = !isRunning ? 'disabled style="opacity: 0.5; cursor: not-allowed;"' : '';
+        const linkWrapper = isRunning ? `href="${monitorUrl}" target="_blank"` : '';
+
+        return `<tr>
+          <td class="mono">${esc(c.id)}</td>
+          <td>${esc(c.name)}</td>
+          <td>${c.node_count}</td>
+          <td class="mono" style="font-size:11px">${c.nodes.control_plane.join(', ')}</td>
+          <td class="mono" style="font-size:11px">${c.nodes.workers.join(', ')}</td>
+          <td>${badge(c.status)}</td>
+          <td>${c.latest_job_id ? `<a href="#" class="mono" style="font-size:12px" onclick="event.preventDefault();goToJob('${c.latest_job_id}')">${esc(c.latest_job_id)}</a>` : '—'}</td>
+          <td style="font-size:12px; color:var(--muted)">${timeAgo(c.created_at)}</td>
+          
+          <td>
+            <a ${linkWrapper} style="text-decoration: none;">
+              <button class="btn btn-cyan btn-sm" ${buttonDisabled}>Monitor</button>
+            </a>
+          </td>
+          
+          <td><button class="btn btn-danger btn-sm" onclick="deleteCluster('${c.id}')">Delete</button></td>
+        </tr>`
+      }).join('')}
     </table>`;
-    // Auto-poll while any cluster is in a transitional state
+    
+
     if (data.some(c => ['creating', 'deleting'].includes(c.status))) {
       _startClusterPoll();
     } else {


### PR DESCRIPTION
Provisioner - provisioner.py
- Added simple debug logging/print output to make provisioning and error tracking easier during testing.(If not needed just drop them)
- Fixed cluster name handling so the correct cluster name is used during setup. Some names given for clusters caused issue like "cluster_1" or "cluster 1" to cluster1

Requirements(requirements.txt)
- Added **httpx** to support backend communication with the Grafana API.

Ansible site.yml
- Added tasks to install Prometheus and Grafana using Helm charts during cluster setup.
- Set up the monitoring stack in the monitoring namespace.

API - monitor.py
- Added a new endpoint: GET **/monitor/open/{cluster_id}** to open the Grafana instance for a specific cluster.
- Securely fetches the Grafana admin password from Kubernetes secrets using SSH.
- Backend now automatically logs in to Grafana by setting the grafana_session cookie, so users skip the login screen.

Database
- Added a new field in the cluster table to store the Grafana password.

Frontend - index.html
- Added a Monitor button on cluster cards that opens the Grafana dashboard for the cluster.

kubectl.py
- Added the jump host logic to kubectl.py because direct SSH was failing. Had to route the traffic through the external network to reach the private cluster IPs. 

**should store the CLUSTER_SSH_PASSWORD and JUMP_HOST in an _.env_**

config.py 
- Moved Grafana URLs and paths to config for easier setup in different environments.